### PR TITLE
Fix deprecation warning on PHP 7.2

### DIFF
--- a/email-address-encoder.php
+++ b/email-address-encoder.php
@@ -102,13 +102,9 @@ function eae_encode_emails( $string ) {
 		}xi'
 	);
 
-	return preg_replace_callback(
-		$regexp,
-		function( $matches ) use ( $method ) {
-			return $method( $matches[0] );
-		},
-		$string
-	);
+	return preg_replace_callback( $regexp, function ( $matches ) use ( $method ) {
+		return $method( $matches[0] );
+	}, $string );
 
 }
 

--- a/email-address-encoder.php
+++ b/email-address-encoder.php
@@ -104,10 +104,9 @@ function eae_encode_emails( $string ) {
 
 	return preg_replace_callback(
 		$regexp,
-		create_function(
-            '$matches',
-            'return ' . $method . '($matches[0]);'
-        ),
+		function( $matches ) use ( $method ) {
+			return $method( $matches[0] );
+		},
 		$string
 	);
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@ Donate link: https://www.paypal.me/tillkruss
 Tags: antispam, anti spam, spam, email, e-mail, mail, spider, crawler, harvester, robots, spambot, block, obfuscate, obfuscation, encode, encoder, encoding, encrypt, encryption, protect, protection
 Requires at least: 2.0
 Tested up to: 4.9
+Requires PHP: 5.3
 Stable tag: 1.0.5
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
- Fixes the deprecation warning PHP 7.2.
- Raises the minimum PHP version to 5.3. 

Note: The minimum PHP version is shown, but not enforced in the WordPress.org plugin repository.