### PR TITLE
Always encode dot

### DIFF
--- a/email-address-encoder.php
+++ b/email-address-encoder.php
@@ -137,7 +137,7 @@ function eae_encode_str( $string ) {
 
 			$r = ( $seed * ( 1 + $key ) ) % 100; // pseudo "random function"
 
-			if ( $r > 60 && $char != '@' ) ; // plain character (not encoded), if not @-sign
+			if ( $r > 60 && $char != '@' && $char != '.' ) ; // plain character (not encoded), if not dot or @-sign
 			else if ( $r < 45 ) $chars[ $key ] = '&#x' . dechex( $ord ) . ';'; // hexadecimal
 			else $chars[ $key ] = '&#' . $ord . ';'; // decimal (ascii)
 

--- a/email-address-encoder.php
+++ b/email-address-encoder.php
@@ -137,7 +137,7 @@ function eae_encode_str( $string ) {
 
 			$r = ( $seed * ( 1 + $key ) ) % 100; // pseudo "random function"
 
-			if ( $r > 60 && $char != '@' && $char != '.' ) ; // plain character (not encoded), if not dot or @-sign
+			if ( $r > 60 && $char !== '@' && $char !== '.' ) ; // plain character (not encoded), except @-signs and dots
 			else if ( $r < 45 ) $chars[ $key ] = '&#x' . dechex( $ord ) . ';'; // hexadecimal
 			else $chars[ $key ] = '&#' . $ord . ';'; // decimal (ascii)
 


### PR DESCRIPTION
Since any valid e-mail address has to contain a dot, we might want to always obfuscate it to make the resulting string look even less like an e-mail address.